### PR TITLE
Use last version of SDKs (without acknowledgements) in tests

### DIFF
--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -11,7 +11,7 @@
         "@dfinity/agent": "^0.19.2",
         "@dfinity/candid": "^0.19.2",
         "@dfinity/principal": "^0.19.2",
-        "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#2b1ff1d8107e21dce1a3df387caa9977a5f49ada"
+        "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#dbee657817525a88189c293229188a9c9b4d5b52"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.22.9",
@@ -11840,8 +11840,8 @@
     },
     "node_modules/ic-websocket-js": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#2b1ff1d8107e21dce1a3df387caa9977a5f49ada",
-      "integrity": "sha512-MYuK+6R2RG5kQqW5dK0RcucJn7zGJKo3yZqG+PVTXVEHxn4NOxD/U26CA/bRtymcEvBfixZnYCN8QnhaIrHL0g==",
+      "resolved": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#dbee657817525a88189c293229188a9c9b4d5b52",
+      "integrity": "sha512-m90BRXjKZsv1M5IdlPkn4ZZSWiDmLvaMGFGy8umzy9H8apPRIE5BYbFzYWkcM85RpFkBhl4fA+GV40qhyz93yg==",
       "hasInstallScript": true,
       "dependencies": {
         "@dfinity/agent": "^0.19.2",
@@ -30050,9 +30050,9 @@
       "dev": true
     },
     "ic-websocket-js": {
-      "version": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#2b1ff1d8107e21dce1a3df387caa9977a5f49ada",
-      "integrity": "sha512-MYuK+6R2RG5kQqW5dK0RcucJn7zGJKo3yZqG+PVTXVEHxn4NOxD/U26CA/bRtymcEvBfixZnYCN8QnhaIrHL0g==",
-      "from": "ic-websocket-js@github:omnia-network/ic-websocket-sdk-js#2b1ff1d8107e21dce1a3df387caa9977a5f49ada",
+      "version": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#dbee657817525a88189c293229188a9c9b4d5b52",
+      "integrity": "sha512-m90BRXjKZsv1M5IdlPkn4ZZSWiDmLvaMGFGy8umzy9H8apPRIE5BYbFzYWkcM85RpFkBhl4fA+GV40qhyz93yg==",
+      "from": "ic-websocket-js@github:omnia-network/ic-websocket-sdk-js#dbee657817525a88189c293229188a9c9b4d5b52",
       "requires": {
         "@dfinity/agent": "^0.19.2",
         "@dfinity/candid": "^0.19.2",

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -47,6 +47,6 @@
     "@dfinity/agent": "^0.19.2",
     "@dfinity/candid": "^0.19.2",
     "@dfinity/principal": "^0.19.2",
-    "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#2b1ff1d8107e21dce1a3df387caa9977a5f49ada"
+    "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#dbee657817525a88189c293229188a9c9b4d5b52"
   }
 }

--- a/tests/load/package-lock.json
+++ b/tests/load/package-lock.json
@@ -8,11 +8,12 @@
       "name": "ic_websocket_gateway_load_tests",
       "version": "0.1.0",
       "dependencies": {
-        "@dfinity/candid": "^0.18.1",
+        "@dfinity/candid": "^0.19.2",
         "bufferutil": "^4.0.7",
         "dotenv": "^16.3.1",
-        "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#41e37667c36d26a535d4247e37711f4bad2184a8",
+        "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#dbee657817525a88189c293229188a9c9b4d5b52",
         "isomorphic-webcrypto": "^2.3.8",
+        "tweetnacl": "^1.0.3",
         "utf-8-validate": "^5.0.10",
         "ws": "^8.13.0"
       },
@@ -3254,42 +3255,46 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-      "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.2.tgz",
+      "integrity": "sha512-KLRWEjeU9SyyaS7IBVJ9ZUcufxufr55e/kRIyClK157+0pkTG9a8xKjUIMx3QzKvLsqqzXL238nWwdoP6jAD8g==",
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/principal": "^0.18.1"
+        "@dfinity/candid": "^0.19.2",
+        "@dfinity/principal": "^0.19.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-      "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg=="
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.2.tgz",
+      "integrity": "sha512-X2hCqNMhnnmwtnOc0WnymOZYx3qphjEMuSYbBr7tMIkV7Hwt9BmXXlLnQTxUytTPxf+3he0GcS3KzsSQ9CK8ew==",
+      "peerDependencies": {
+        "@dfinity/principal": "^0.19.2"
+      }
     },
     "node_modules/@dfinity/identity-secp256k1": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.18.1.tgz",
-      "integrity": "sha512-3yaXQ2awLJAprarMjhtv8XtXMV8+AfqF6Q6Et0K3qMzIwgff31WQrl/98ZzP5QLs0vfeT1Q8yJT2OFuhwgL2nA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.19.2.tgz",
+      "integrity": "sha512-rzkmNE9n1XWicjt9R4kw3gpZimoalIoR5TLbXPaBILUvNNO7aGZ6Cz5bvrq8HI14yETkxAXNL5rjGwAtoFqAhQ==",
       "dependencies": {
-        "@dfinity/agent": "^0.18.1",
+        "@dfinity/agent": "^0.19.2",
+        "@noble/hashes": "^1.3.1",
         "bip39": "^3.0.4",
         "bs58check": "^2.1.2",
         "secp256k1": "^4.0.3"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-      "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.2.tgz",
+      "integrity": "sha512-vsKN6BKya70bQUsjgKRDlR2lOpv/XpUkCMIiji6rjMtKHIuWEB5Eu3JqZsOuBmWo3A3TT/K/osT9VPm0k4qdYQ==",
       "dependencies": {
-        "js-sha256": "^0.9.0"
+        "@noble/hashes": "^1.3.1"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -6103,21 +6108,10 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "devOptional": true
     },
-    "node_modules/@noble/ed25519": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
-      "integrity": "sha512-/extjhkwFupyopDrt80OMWKdLgP429qLZj+z6sYJz90rF2Iz0gjZh2ArMKPImUl13Kx+0EXI2hN9T/KJV0/Zng==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "engines": {
         "node": ">= 16"
       },
@@ -15011,15 +15005,14 @@
     },
     "node_modules/ic-websocket-js": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#41e37667c36d26a535d4247e37711f4bad2184a8",
-      "integrity": "sha512-kwWnRht41Jx6LN/QQ05zqBCIh6QTZu978z77nxhNY0fcGC8EgXFMZFJMaBsetWC5dlQtV/sVv438uyW+4A7PEw==",
+      "resolved": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#dbee657817525a88189c293229188a9c9b4d5b52",
+      "integrity": "sha512-m90BRXjKZsv1M5IdlPkn4ZZSWiDmLvaMGFGy8umzy9H8apPRIE5BYbFzYWkcM85RpFkBhl4fA+GV40qhyz93yg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/identity-secp256k1": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
-        "@noble/ed25519": "^2.0.0",
+        "@dfinity/agent": "^0.19.2",
+        "@dfinity/candid": "^0.19.2",
+        "@dfinity/identity-secp256k1": "^0.19.2",
+        "@dfinity/principal": "^0.19.2",
         "loglevel": "^1.8.1"
       },
       "engines": {
@@ -16613,11 +16606,6 @@
       "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
       "optional": true,
       "peer": true
-    },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -22607,6 +22595,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -26314,38 +26307,40 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.18.1.tgz",
-      "integrity": "sha512-nMFK/y0ZkPfQYECdojmltXsBIdGvXa1Sxa4rDV2cibEq9lsjWMEIUqPsiBaNHuwuz+gzsGVq4N2b9umKQIQaRQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.2.tgz",
+      "integrity": "sha512-KLRWEjeU9SyyaS7IBVJ9ZUcufxufr55e/kRIyClK157+0pkTG9a8xKjUIMx3QzKvLsqqzXL238nWwdoP6jAD8g==",
       "requires": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
         "simple-cbor": "^0.4.1"
       }
     },
     "@dfinity/candid": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.18.1.tgz",
-      "integrity": "sha512-/PC3wDnrGcWhaF/veYKevcAAn5A5jK0mRkVKcz0YxK/a78Ai9wMJg0fUk7aoyZryCOz8JPVgR4nK1/zTmvEBHg=="
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.2.tgz",
+      "integrity": "sha512-X2hCqNMhnnmwtnOc0WnymOZYx3qphjEMuSYbBr7tMIkV7Hwt9BmXXlLnQTxUytTPxf+3he0GcS3KzsSQ9CK8ew==",
+      "requires": {}
     },
     "@dfinity/identity-secp256k1": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.18.1.tgz",
-      "integrity": "sha512-3yaXQ2awLJAprarMjhtv8XtXMV8+AfqF6Q6Et0K3qMzIwgff31WQrl/98ZzP5QLs0vfeT1Q8yJT2OFuhwgL2nA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-0.19.2.tgz",
+      "integrity": "sha512-rzkmNE9n1XWicjt9R4kw3gpZimoalIoR5TLbXPaBILUvNNO7aGZ6Cz5bvrq8HI14yETkxAXNL5rjGwAtoFqAhQ==",
       "requires": {
-        "@dfinity/agent": "^0.18.1",
+        "@dfinity/agent": "^0.19.2",
+        "@noble/hashes": "^1.3.1",
         "bip39": "^3.0.4",
         "bs58check": "^2.1.2",
         "secp256k1": "^4.0.3"
       }
     },
     "@dfinity/principal": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.18.1.tgz",
-      "integrity": "sha512-xeV+5zV7VQRT2xJTbXW4IDra1urEcchuwuKFTU/ERcJWBWEk8chsZcd6DBc8SPq83xRgXW2ZTVVSOZR8NKaVoQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.2.tgz",
+      "integrity": "sha512-vsKN6BKya70bQUsjgKRDlR2lOpv/XpUkCMIiji6rjMtKHIuWEB5Eu3JqZsOuBmWo3A3TT/K/osT9VPm0k4qdYQ==",
       "requires": {
-        "js-sha256": "^0.9.0"
+        "@noble/hashes": "^1.3.1"
       }
     },
     "@discoveryjs/json-ext": {
@@ -28554,15 +28549,10 @@
         }
       }
     },
-    "@noble/ed25519": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
-      "integrity": "sha512-/extjhkwFupyopDrt80OMWKdLgP429qLZj+z6sYJz90rF2Iz0gjZh2ArMKPImUl13Kx+0EXI2hN9T/KJV0/Zng=="
-    },
     "@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -35580,15 +35570,14 @@
       "dev": true
     },
     "ic-websocket-js": {
-      "version": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#41e37667c36d26a535d4247e37711f4bad2184a8",
-      "integrity": "sha512-kwWnRht41Jx6LN/QQ05zqBCIh6QTZu978z77nxhNY0fcGC8EgXFMZFJMaBsetWC5dlQtV/sVv438uyW+4A7PEw==",
-      "from": "ic-websocket-js@github:omnia-network/ic-websocket-sdk-js#41e37667c36d26a535d4247e37711f4bad2184a8",
+      "version": "git+ssh://git@github.com/omnia-network/ic-websocket-sdk-js.git#dbee657817525a88189c293229188a9c9b4d5b52",
+      "integrity": "sha512-m90BRXjKZsv1M5IdlPkn4ZZSWiDmLvaMGFGy8umzy9H8apPRIE5BYbFzYWkcM85RpFkBhl4fA+GV40qhyz93yg==",
+      "from": "ic-websocket-js@github:omnia-network/ic-websocket-sdk-js#dbee657817525a88189c293229188a9c9b4d5b52",
       "requires": {
-        "@dfinity/agent": "^0.18.1",
-        "@dfinity/candid": "^0.18.1",
-        "@dfinity/identity-secp256k1": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
-        "@noble/ed25519": "^2.0.0",
+        "@dfinity/agent": "^0.19.2",
+        "@dfinity/candid": "^0.19.2",
+        "@dfinity/identity-secp256k1": "^0.19.2",
+        "@dfinity/principal": "^0.19.2",
         "loglevel": "^1.8.1"
       }
     },
@@ -36792,11 +36781,6 @@
       "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
       "optional": true,
       "peer": true
-    },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -41432,6 +41416,11 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+    },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/tests/load/package.json
+++ b/tests/load/package.json
@@ -6,11 +6,12 @@
     "test": "./scripts/run_load_tests.sh"
   },
   "dependencies": {
-    "@dfinity/candid": "^0.18.1",
+    "@dfinity/candid": "^0.19.2",
     "bufferutil": "^4.0.7",
     "dotenv": "^16.3.1",
-    "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#41e37667c36d26a535d4247e37711f4bad2184a8",
+    "ic-websocket-js": "github:omnia-network/ic-websocket-sdk-js#dbee657817525a88189c293229188a9c9b4d5b52",
     "isomorphic-webcrypto": "^2.3.8",
+    "tweetnacl": "^1.0.3",
     "utf-8-validate": "^5.0.10",
     "ws": "^8.13.0"
   },

--- a/tests/test_canister/Cargo.lock
+++ b/tests/test_canister/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "candid"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f6eec0ae850e006ef0fe306f362884d370624094ec55a6a26de18b251774be"
+checksum = "f391a0d11d997af68e1a06b5e2ab354079cecb82b6eefb26addb38adf66d351d"
 dependencies = [
  "anyhow",
  "binread",
@@ -356,7 +356,7 @@ dependencies = [
 [[package]]
 name = "ic-websocket-cdk"
 version = "0.1.0"
-source = "git+https://github.com/omnia-network/ic-websocket-cdk-rs?rev=ca118f23fc5ae52cc195e708eaa51e1dd8638c63#ca118f23fc5ae52cc195e708eaa51e1dd8638c63"
+source = "git+https://github.com/omnia-network/ic-websocket-cdk-rs?rev=18a892055d866d602038db3ba6e1f1a1102eeac7#18a892055d866d602038db3ba6e1f1a1102eeac7"
 dependencies = [
  "base64",
  "candid",
@@ -488,13 +488,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pretty"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
+checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
  "arrayvec",
  "typed-arena",
- "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -730,12 +730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,9 +759,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]

--- a/tests/test_canister/src/test_canister/Cargo.toml
+++ b/tests/test_canister/src/test_canister/Cargo.toml
@@ -11,4 +11,4 @@ candid = "0.9.3"
 ic-cdk = "0.10.0"
 ic-cdk-macros = "0.7.1"
 serde = "1.0.176"
-ic-websocket-cdk = { git = "https://github.com/omnia-network/ic-websocket-cdk-rs", rev = "ca118f23fc5ae52cc195e708eaa51e1dd8638c63" }
+ic-websocket-cdk = { git = "https://github.com/omnia-network/ic-websocket-cdk-rs", rev = "18a892055d866d602038db3ba6e1f1a1102eeac7" }


### PR DESCRIPTION
Fixes load tests and updates SDKs for both load and integration tests. The SDKs used don't have the acknowledgement logic implemented.