### PR TITLE
fix: tests package included for build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ docs/
 scripts/
 target/
 tests/
+!tests/test_canister_rs/src/test_canister_rs
 volumes/
 .editorconfig
 .env.example


### PR DESCRIPTION
Docker build was failing due to missing `tests/test_canister_rs/src/test_canister_rs` package in the Docker `COPY` command.