### PR TITLE
remove poller immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
 
 [[package]]
 name = "ic_websocket_gateway"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "async-trait",
  "candid",

--- a/src/ic-websocket-gateway/Cargo.toml
+++ b/src/ic-websocket-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic_websocket_gateway"
-version = "1.2.2"
+version = "1.2.3"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Check whether the poller state is empty after each polling iteration. This is not efficient and needs to be improved but it is necessary to make the protocol safe.